### PR TITLE
Support for Maven type (Groovy extension)

### DIFF
--- a/src/main/groovy/ca/cutterslade/gradle/maven/thief/PomDependency.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/maven/thief/PomDependency.groovy
@@ -23,7 +23,9 @@ class PomDependency {
   String artifactId
   String version
   String classifier
+  String type
   Scope scope
+
   Set<PomDependency> exclusions
 
   private PomDependency keyDep
@@ -32,7 +34,7 @@ class PomDependency {
     def depMan = dependencyManagement[asKey()]
     null == depMan || (depMan.version == version && depMan.scope == scope) ? this :
         new PomDependency(groupId: groupId, artifactId: artifactId,
-            version: version ?: depMan.version, classifier: classifier, scope: scope ?: depMan.scope,
+            version: version ?: depMan.version, type: type?: depMan.type, classifier: classifier, scope: scope ?: depMan.scope,
             exclusions: depMan.exclusions ? depMan.exclusions + exclusions : exclusions)
   }
 
@@ -45,9 +47,18 @@ class PomDependency {
   }
 
   Dependency getGradleDependency(Project project) {
-    project.dependencies.create("$groupId:$artifactId:$version${classifier ? ":$classifier" : ''}", {
-      exclusions.each { exclude(group: it.groupId, module: it.artifactId) }
-    })
+    if ("jar".equals(type)) {
+      String groovyDep = "$groupId:$artifactId:$version${classifier ? ":$classifier" : ''}"
+      project.dependencies.create(groovyDep, {
+        exclusions.each { exclude(group: it.groupId, module: it.artifactId) }
+      })
+    }
+    else {
+      String groovyDep = "$groupId:$artifactId:$version${classifier ? ":$classifier" : ''}@$type"
+      project.dependencies.create(groovyDep, {
+        exclusions.each { exclude(group: it.groupId, module: it.artifactId) }
+      })
+    }
   }
 
   Configuration getGradleConfiguration(Project project) {

--- a/src/main/groovy/ca/cutterslade/gradle/maven/thief/PomHandler.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/maven/thief/PomHandler.groovy
@@ -117,6 +117,8 @@ class PomHandler {
       String artifactId = dependency.artifactId.text()
       String classifier = dependency.classifier ? dependency.classifier.text() : null
       String version = dependency.version ? dependency.version.text() : null
+      String type = dependency.type && !dependency.type.text().isEmpty() ? dependency.type.text() : "jar"
+
       String scope = dependency.scope ? dependency.scope.text() : null
       def dep = new PomDependency(
           groupId: resolveProperties(groupId),
@@ -124,9 +126,11 @@ class PomHandler {
           version: resolveProperties(version),
           classifier: resolveProperties(classifier),
           scope: PomDependency.Scope.of(resolveProperties(scope)),
+          type: resolveProperties(type),
           exclusions: parseExclusions(dependency))
       [(dep.asKey()): dep.withManagement(dependencyManagement)]
     })
+
     dependencies
   }
 


### PR DESCRIPTION
Maven has dependencies which have the same groupId but different type values.  These dependencies are not being picked up by the plugin.

    <dependency>
      <groupId>org.apache.rampart</groupId>
      <artifactId>rampart</artifactId>
      <type>mar</type>
      <version>1.5</version>
      <scope>runtime</scope>
    </dependency>

For these dependencies we can use artifact only notation:

https://docs.gradle.org/current/userguide/dependency_management.html#sub:module_dependencies

`runtime "org.apache.rampart:rampart:1.5@mar"`